### PR TITLE
Fixing the import of xsrftoken lib after it has been moved to github.

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -72,7 +72,7 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/xsrftoken"
+	"github.com/adg/xsrftoken"
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/sessions"
 )


### PR DESCRIPTION
The `xsrftoken` library cannot be loaded through Google Code as the service has been shutdown. The author of this library has moved the code to Github (http://github.com/adg/xsrftoken), so we've changed the dependency to point there.